### PR TITLE
Docs: URLs have changed after migration

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -33,5 +33,4 @@ Assuming the application server is deployed, you should be able to see relativel
 
 * [Haiku homepage](http://www.haiku-os.org)
 * [HaikuPorts homepage](https://github.com/haikuports/haikuports/wiki) (for external packages)
-* Haiku [package management documentation](http://dev.haiku-os.org/wiki/PackageManagement)
-* [Usage help](https://dev.haiku-os.org/wiki/PackageManagement/HaikuDepotServer)
+* Haiku [package management documentation](https://github.com/haiku/haiku/blob/master/docs/develop/packages/README.wiki)


### PR DESCRIPTION
With hrev51749 the documentation of the package management was
migrated from the Trac wiki into the Haiku tree. The wiki pages
were moved to under 'Obsolete' without redirection.

Removed link to https://dev.haiku-os.org/wiki/PackageManagement/HaikuDepotServer).
That, too was moved to 'Obsolete', but wasn't put into the tree.